### PR TITLE
fix: fix "no views" string returned by youtube

### DIFF
--- a/run.py
+++ b/run.py
@@ -166,7 +166,7 @@ def download_playlist(spotify_playlist_id, folder_name):
                 song_duration = int(sd_data[0]) * 60  + int(sd_data[1])
 
                 viewcount = re.sub('[^0-9]','', yt_data['views'])
-                song_viewcount = int(viewcount) if viewcount.isdigit() else 0
+                song_viewcount = int(viewcount) if str(viewcount).isdigit() else 0
 
                 song_link = "https://www.youtube.com" + yt_data['url_suffix']
                 song_albumc_link = yt_data['thumbnails'][0]

--- a/run.py
+++ b/run.py
@@ -165,7 +165,8 @@ def download_playlist(spotify_playlist_id, folder_name):
                 sd_data = yt_data['duration'].split(':')
                 song_duration = int(sd_data[0]) * 60  + int(sd_data[1])
 
-                song_viewcount = int(re.sub('[^0-9]','', yt_data['views']))
+                viewcount = re.sub('[^0-9]','', yt_data['views'])
+                song_viewcount = int(viewcount) if viewcount.isdigit() else 0
 
                 song_link = "https://www.youtube.com" + yt_data['url_suffix']
                 song_albumc_link = yt_data['thumbnails'][0]


### PR DESCRIPTION
When a song has "No views" on youtube, a string is returned from yt, so the `int()` cast is impossible and raises an error. Added a test to verify it's a string or an integer before parsing it within `int()`