### PR TITLE
feat: add centralized CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,11 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  validation:
+    uses: emmet02/.github/.github/workflows/ci.yml@main
+    secrets: inherit

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,10 @@
+name: Auto Label PRs
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+jobs:
+  labeler:
+    uses: emmet02/.github/.github/workflows/pr-labeler.yml@main
+    secrets: inherit

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,12 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    uses: emmet02/.github/.github/workflows/release-please.yml@main
+    with:
+      release_type: python
+    secrets: inherit


### PR DESCRIPTION
Initializes the repository with centralized CI, PR labeling, and automated release management via `emmet02/.github`.