### PR TITLE
Fix auth and youtube downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,16 @@ Brew yourself a coffee, you deserved it!
 
 To download user-specific content, you will need to set up a Spotify Developer App:
 
-1. Go to the [Spotify Developer Dashboard](https://developer.spotify.com/dashboard/) and log in with your Spotify account.
+1. Go to the [Spotify Developer Dashboard](https://developer.spotify.com/dashboard/) 
+   and log in with your Spotify account.
 2. Click **Create an App**. Give it a name and description.
 3. In the App settings, edit the **Redirect URIs**.
-4. Add the following Redirect URI EXACTLY as written: `http://127.0.0.1:5000/callback` (Do NOT use `localhost`).
+4. Add the following Redirect URI EXACTLY as written: 
+   `http://127.0.0.1:5000/callback` (Do NOT use `localhost`).
 5. Save the settings.
 6. Note down your **Client ID** and **Client Secret**.
-7. Run the script (e.g., `python spotify2mp3.py --liked`). When prompted, paste the Client ID and Client Secret into the terminal.
+7. Run the script (e.g., `python spotify2mp3.py --liked`). When prompted, 
+   paste the Client ID and Client Secret into the terminal.
 
 ## Getting spotify playlist URL
 

--- a/README.md
+++ b/README.md
@@ -95,15 +95,15 @@ Brew yourself a coffee, you deserved it!
 
 To download user-specific content, you will need to set up a Spotify Developer App:
 
-1. Go to the [Spotify Developer Dashboard](https://developer.spotify.com/dashboard/) 
+1. Visit the [Spotify Dev Dashboard](https://developer.spotify.com/dashboard/)
    and log in with your Spotify account.
 2. Click **Create an App**. Give it a name and description.
 3. In the App settings, edit the **Redirect URIs**.
-4. Add the following Redirect URI EXACTLY as written: 
+4. Add the following Redirect URI EXACTLY as written:
    `http://127.0.0.1:5000/callback` (Do NOT use `localhost`).
 5. Save the settings.
 6. Note down your **Client ID** and **Client Secret**.
-7. Run the script (e.g., `python spotify2mp3.py --liked`). When prompted, 
+7. Run the script (e.g., `python spotify2mp3.py --liked`). When prompted,
    paste the Client ID and Client Secret into the terminal.
 
 ## Getting spotify playlist URL

--- a/README.md
+++ b/README.md
@@ -91,6 +91,18 @@ Brew yourself a coffee, you deserved it!
 
 `If this project helped you, feel free to give us a star`
 
+## :key: Spotify App Setup (Required for Liked Songs / Private Playlists)
+
+To download user-specific content, you will need to set up a Spotify Developer App:
+
+1. Go to the [Spotify Developer Dashboard](https://developer.spotify.com/dashboard/) and log in with your Spotify account.
+2. Click **Create an App**. Give it a name and description.
+3. In the App settings, edit the **Redirect URIs**.
+4. Add the following Redirect URI EXACTLY as written: `http://127.0.0.1:5000/callback` (Do NOT use `localhost`).
+5. Save the settings.
+6. Note down your **Client ID** and **Client Secret**.
+7. Run the script (e.g., `python spotify2mp3.py --liked`). When prompted, paste the Client ID and Client Secret into the terminal.
+
 ## Getting spotify playlist URL
 
 Paste a Spotify Song, Playlist or Album URL into the program. You can also specify 'liked' to retrieve your liked songs.

--- a/apis/spotify.py
+++ b/apis/spotify.py
@@ -6,6 +6,14 @@ import sys
 import login
 
 import tekore as tk
+from typing import Optional
+
+# Monkey-patch tekore to make track popularity optional
+# Spotify API occasionally omits the popularity field, avoiding Pydantic validation errors
+tk.model.FullTrack.__annotations__['popularity'] = Optional[int]
+if hasattr(tk.model.FullTrack, 'model_fields'):  # Pydantic V2
+    tk.model.FullTrack.model_fields['popularity'].default = None
+    tk.model.FullTrack.model_rebuild(force=True)
 
 import const
 

--- a/apis/youtube.py
+++ b/apis/youtube.py
@@ -1,6 +1,6 @@
 from exceptions import ConfigVideoLowViewCount, ConfigVideoMaxLength, YoutubeItemNotFound
-from pytube import YouTube as pytubeYouTube
-from pytube import Playlist as pytubePlaylist
+from pytubefix import YouTube as pytubeYouTube
+from pytubefix import Playlist as pytubePlaylist
 from youtube_search import YoutubeSearch
 import json
 

--- a/apis/youtube.py
+++ b/apis/youtube.py
@@ -1,6 +1,5 @@
 from exceptions import ConfigVideoLowViewCount, ConfigVideoMaxLength, YoutubeItemNotFound
 from pytubefix import YouTube as pytubeYouTube
-from pytubefix import Playlist as pytubePlaylist
 from youtube_search import YoutubeSearch
 import json
 

--- a/downloader.py
+++ b/downloader.py
@@ -1,5 +1,5 @@
 from const import colours
-from pytube.exceptions import AgeRestrictedError
+from pytubefix.exceptions import AgeRestrictedError
 from exceptions import SpotifyAlbumNotFound, SpotifyTrackNotFound, SpotifyPlaylistNotFound, ConfigVideoMaxLength, ConfigVideoLowViewCount, YoutubeItemNotFound
 from apis.spotify import Spotify
 from utils import resave_audio_clip_with_metadata

--- a/login.py
+++ b/login.py
@@ -21,7 +21,7 @@ auths = {}  # Auth attempts. Stores data across spotify login
 flask_process = None
 
 cfg_filename = 'tekore_cfg.ini'
-app_host = "localhost"
+app_host = "127.0.0.1"
 app_port = 5000
 app_url = f'http://{app_host}:{app_port}'
 login_redirect_url = f'{app_url}/callback'
@@ -120,10 +120,9 @@ def do_user_login():
     try:
         userToken = get_user_token()
         spotify = tk.Spotify(userToken)
-        topTracks = spotify.current_user_top_tracks()
+        user = spotify.current_user()
 
-        item = topTracks.items[0]
-        print(f'\n{colours.OKBLUE}It worked! {colours.ENDC}Your Top Track is: {item.name} by {item.artists[0].name}\n\n')
+        print(f'\n{colours.OKBLUE}It worked! {colours.ENDC}Logged in as: {user.display_name}\n\n')
     except tk.HTTPError as e:
         if is_client_configured():
             os.remove(cfg_filename)

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,4 @@ python-Levenshtein==0.12.2
 tekore==5.0.1
 flask==2.2.5
 Werkzeug==2.2.2
-git+https://github.com/abanand132/pytube.git@master#egg=pytube
+pytubefix


### PR DESCRIPTION
### Summary
This PR fixes multiple breaking issues caused by recent downstream API changes from YouTube and Spotify.

### Changes
* **YouTube**: Migrated from the broken `pytube` package to the actively maintained `pytubefix` library to resolve `HTTP Error 400: Bad Request` download errors.
* **Spotify Auth**: Updated the application Redirect URI from `localhost` to `127.0.0.1` and added a Spotify App setup guide to the `README.md` to comply with new Spotify Developer Dashboard restrictions.
* **Spotify API**: Monkey-patched the `tekore` models to make track `popularity` optional, preventing strict Pydantic validation crashes when fetching saved tracks.

### Testing
* Logged into Spotify successfully.
* Retrieved 100+ Liked Songs without API validation errors.
* Downloaded and converted YouTube audio tracks without encountering 400 Bad Request errors.